### PR TITLE
chore: mysql 의존성 추가 및 yml 파일 설정, 도메인 entity 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,8 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'com.mysql:mysql-connector-j'
+	runtimeOnly 'com.mysql:mysql-connector-j'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/moata/moata/domain/article/entity/Article.java
+++ b/src/main/java/com/moata/moata/domain/article/entity/Article.java
@@ -1,0 +1,30 @@
+package com.moata.moata.domain.article.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class Article {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "article_id", nullable = false)
+    private long articleId;
+
+    @Column(name = "content", length = 10000)
+    private String content;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "created_by", nullable = false, length = 10)
+    private String createdBy;
+}

--- a/src/main/java/com/moata/moata/domain/article/entity/Article.java
+++ b/src/main/java/com/moata/moata/domain/article/entity/Article.java
@@ -8,10 +8,11 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
-@AllArgsConstructor
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Getter
 @Entity
+@Getter
+@Table(name = "article")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class Article {
 
     @Id

--- a/src/main/java/com/moata/moata/domain/article/entity/ArticleComment.java
+++ b/src/main/java/com/moata/moata/domain/article/entity/ArticleComment.java
@@ -1,0 +1,35 @@
+package com.moata.moata.domain.article.entity;
+
+import com.moata.moata.domain.group.entity.Group;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class ArticleComment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "comment_id", nullable = false)
+    private long commentId;
+
+    @ManyToOne
+    @JoinColumn(name = "article_id", nullable = false)
+    private Article article;
+
+    @Column(name = "content", length = 10000)
+    private String content;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "created_by", nullable = false, length = 10)
+    private String createdBy;
+}

--- a/src/main/java/com/moata/moata/domain/article/entity/ArticleComment.java
+++ b/src/main/java/com/moata/moata/domain/article/entity/ArticleComment.java
@@ -9,10 +9,11 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
-@AllArgsConstructor
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Getter
 @Entity
+@Getter
+@Table(name = "article_comment")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class ArticleComment {
 
     @Id

--- a/src/main/java/com/moata/moata/domain/faq/entity/Faq.java
+++ b/src/main/java/com/moata/moata/domain/faq/entity/Faq.java
@@ -6,10 +6,11 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@AllArgsConstructor
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Getter
 @Entity
+@Getter
+@Table(name = "faq")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class Faq {
 
     @Id

--- a/src/main/java/com/moata/moata/domain/faq/entity/Faq.java
+++ b/src/main/java/com/moata/moata/domain/faq/entity/Faq.java
@@ -1,0 +1,25 @@
+package com.moata.moata.domain.faq.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class Faq {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "faq_id", nullable = false)
+    private long faqId;
+
+    @Column(name = "title", nullable = false)
+    private String title;
+
+    @Column(name = "content", nullable = false, length = 10000)
+    private String content;
+}

--- a/src/main/java/com/moata/moata/domain/group/entity/Group.java
+++ b/src/main/java/com/moata/moata/domain/group/entity/Group.java
@@ -1,0 +1,34 @@
+package com.moata.moata.domain.group.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class Group {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "group_id", nullable = false)
+    private long groupId;
+
+    @Column(name = "owner_name", nullable = false, length = 10)
+    private String ownerName;
+
+    @Column(name = "favorite_area")
+    private String favoriteArea;
+
+    @Column(name = "co_owner_max")
+    private int coOwnerMax;
+
+    @Column(name = "car_use_frequency")
+    private int carUseFrequency;
+
+    @Column(name = "car_type")
+    private String carType;
+}

--- a/src/main/java/com/moata/moata/domain/group/entity/Group.java
+++ b/src/main/java/com/moata/moata/domain/group/entity/Group.java
@@ -5,11 +5,15 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicInsert;
 
-@AllArgsConstructor
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Getter
 @Entity
+@Getter
+@Table(name = "user_group")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@DynamicInsert
 public class Group {
 
     @Id
@@ -24,9 +28,11 @@ public class Group {
     private String favoriteArea;
 
     @Column(name = "co_owner_max")
+    @ColumnDefault("0")
     private int coOwnerMax;
 
     @Column(name = "car_use_frequency")
+    @ColumnDefault("0")
     private int carUseFrequency;
 
     @Column(name = "car_type")

--- a/src/main/java/com/moata/moata/domain/group/entity/GroupRule.java
+++ b/src/main/java/com/moata/moata/domain/group/entity/GroupRule.java
@@ -6,10 +6,11 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@AllArgsConstructor
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Getter
 @Entity
+@Getter
+@Table(name = "group_rule")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class GroupRule {
 
     @Id

--- a/src/main/java/com/moata/moata/domain/group/entity/GroupRule.java
+++ b/src/main/java/com/moata/moata/domain/group/entity/GroupRule.java
@@ -1,0 +1,35 @@
+package com.moata.moata.domain.group.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class GroupRule {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "group_rule_id", nullable = false)
+    private long groupRuleId;
+
+    @ManyToOne
+    @JoinColumn(name = "group_id", nullable = false)
+    private Group group;
+
+    @Column(name = "washing_frequency", nullable = false, length = 30)
+    private String washingFrequency;
+
+    @Column(name = "fuel_manager", nullable = false, length = 10)
+    private String fuelManager;
+
+    @Column(name = "parking_location", nullable = false)
+    private String parkingLocation;
+
+    @Column(name = "another", length = 5000)
+    private String another;
+}

--- a/src/main/java/com/moata/moata/domain/notice/entity/Notice.java
+++ b/src/main/java/com/moata/moata/domain/notice/entity/Notice.java
@@ -6,10 +6,11 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@AllArgsConstructor
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Getter
 @Entity
+@Getter
+@Table(name = "notice")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class Notice {
 
     @Id

--- a/src/main/java/com/moata/moata/domain/notice/entity/Notice.java
+++ b/src/main/java/com/moata/moata/domain/notice/entity/Notice.java
@@ -1,0 +1,25 @@
+package com.moata.moata.domain.notice.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class Notice {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "notice_id", nullable = false)
+    private long noticeId;
+
+    @Column(name = "title", nullable = false)
+    private String title;
+
+    @Column(name = "content", nullable = false, length = 10000)
+    private String content;
+}

--- a/src/main/java/com/moata/moata/domain/reservation/entity/Reservation.java
+++ b/src/main/java/com/moata/moata/domain/reservation/entity/Reservation.java
@@ -6,13 +6,15 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicInsert;
 
 import java.time.LocalDateTime;
 
-@AllArgsConstructor
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Getter
 @Entity
+@Getter
+@Table(name = "reservation")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class Reservation {
 
     @Id

--- a/src/main/java/com/moata/moata/domain/reservation/entity/Reservation.java
+++ b/src/main/java/com/moata/moata/domain/reservation/entity/Reservation.java
@@ -1,0 +1,47 @@
+package com.moata.moata.domain.reservation.entity;
+
+import com.moata.moata.domain.group.entity.Group;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class Reservation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "reservation_id", nullable = false)
+    private long reservationId;
+
+    @ManyToOne
+    @JoinColumn(name = "group_id", nullable = false)
+    private Group group;
+
+    @Column(name = "reserver_name", nullable = false, length = 10)
+    private String reserverName;
+
+    @Column(name = "start_time", nullable = false)
+    private LocalDateTime startTime;
+
+    @Column(name = "end_time", nullable = false)
+    private LocalDateTime endTime;
+
+    @Column(name = "is_ride_sharing", nullable = false)
+    private Boolean isRideSharing;
+
+    @Column(name = "ride_sharing_role", length = 10)
+    private String rideSharingRole;
+
+    @Column(name = "departure")
+    private String departure;
+
+    @Column(name = "destination")
+    private String destination;
+}

--- a/src/main/java/com/moata/moata/domain/user/entity/LikeUser.java
+++ b/src/main/java/com/moata/moata/domain/user/entity/LikeUser.java
@@ -1,0 +1,27 @@
+package com.moata.moata.domain.user.entity;
+
+import com.moata.moata.domain.group.entity.Group;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class LikeUser {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "like_id", nullable = false)
+    private long likeId;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "liked_id", nullable = false)
+    private long likedId;
+}

--- a/src/main/java/com/moata/moata/domain/user/entity/LikeUser.java
+++ b/src/main/java/com/moata/moata/domain/user/entity/LikeUser.java
@@ -7,10 +7,11 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@AllArgsConstructor
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Getter
 @Entity
+@Getter
+@Table(name = "like_user")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class LikeUser {
 
     @Id

--- a/src/main/java/com/moata/moata/domain/user/entity/User.java
+++ b/src/main/java/com/moata/moata/domain/user/entity/User.java
@@ -1,0 +1,31 @@
+package com.moata.moata.domain.user.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id", nullable = false)
+    private long userId;
+
+    @Column(name = "name", nullable = false, length = 10)
+    private String name;
+
+    @Column(name = "phone", nullable = false)
+    private long phone;
+
+    @Column(name = "telco", nullable = false, length = 10)
+    private String telco;
+
+    @Column(name = "location", nullable = false)
+    private String location;
+}

--- a/src/main/java/com/moata/moata/domain/user/entity/User.java
+++ b/src/main/java/com/moata/moata/domain/user/entity/User.java
@@ -6,10 +6,11 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@AllArgsConstructor
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Getter
 @Entity
+@Getter
+@Table(name = "user")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class User {
 
     @Id

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=moata

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,9 +2,9 @@ spring:
   datasource:
     # MySQL
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:3306/moata
-    username:
-    password:
+    url: jdbc:mysql://localhost:3306/${DB_NAME}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
   jpa:
     hibernate:
       ddl-auto: create

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,14 @@
+spring:
+  datasource:
+    # MySQL
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://localhost:3306/moata
+    username:
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true


### PR DESCRIPTION
현재 yml 파일 내부에 db 테이블 명, db 사용자 및 비밀번호 값은 환경변수 처리해두었습니다.

📌 변경 사항
- 각 도메인에 대한 Entity 클래스 추가
    - Article, ArticleComment
    - Faq
    - Notice
    - Group, GroupRule
    - Reservation
    - User, LikeUser
- mysql 의존성 추가
- yml 파일 설정(JPA, MySQL)

📌 참고 사항
Group 엔티티는 MySQL 예약어(group) 충돌 가능성이 있어, 테이블 명을 `user_group`으로 수정하였습니다.